### PR TITLE
Add Force_Update Field

### DIFF
--- a/app/models/marked_park.rb
+++ b/app/models/marked_park.rb
@@ -5,7 +5,7 @@ class MarkedPark < ApplicationRecord
   has_many :differences
 
   after_find do |park|
-    update_status() if self.updated_at < Date.yesterday
+    update_status if self.updated_at < Date.yesterday
   end
 
   def next
@@ -44,8 +44,11 @@ class MarkedPark < ApplicationRecord
     elsif rvparky_input.is_a?(Integer)
       self.status = 'INVALID RVPARKY RESPONSE: ' + rvparky_input.to_s
     else
-      self.status = 'NO CONNECTION'
+      self.status = 'INVALID CONNECTIONS'
     end
+
+    self.force_update = !self.force_update
+    self.save
   end
 
   def get_catalogue_data(rv_uuid)

--- a/db/migrate/20180904152926_add_force_updateto_marked_park.rb
+++ b/db/migrate/20180904152926_add_force_updateto_marked_park.rb
@@ -1,0 +1,5 @@
+class AddForceUpdatetoMarkedPark < ActiveRecord::Migration[5.2]
+  def change
+    add_column :marked_parks, :force_update, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_31_170423) do
+ActiveRecord::Schema.define(version: 2018_09_04_152926) do
 
   create_table "differences", force: :cascade do |t|
     t.string "catalogue_field"
@@ -32,6 +32,8 @@ ActiveRecord::Schema.define(version: 2018_08_31_170423) do
     t.datetime "updated_at", null: false
     t.string "slug"
     t.boolean "editable"
+    t.boolean "force_update", default: false
+    t.index ["uuid"], name: "index_marked_parks_on_uuid", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Adds a Force_Update field in marked park, whose only purpose is to be toggled whenever a park checks its status via web services. This ensures that the updated_at field is set to the current time, so that the object doesn't constantly check web services to ensure that it is up to date.